### PR TITLE
Buttonfactory

### DIFF
--- a/src/main/java/com/spartronics4915/frc2020/ButtonFactory.java
+++ b/src/main/java/com/spartronics4915/frc2020/ButtonFactory.java
@@ -1,0 +1,86 @@
+package com.spartronics4915.frc2020;
+
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import edu.wpi.first.wpilibj2.command.button.Button;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj.Joystick;
+
+public class ButtonFactory
+{
+    /**
+     * create a joystick button if the current machine configuration
+     * supports it. We dance this little jig to reduce console spewage.
+     * @param js
+     * @param buttonid
+     * @return either a Joystick button or an InvalidButton
+     */
+    static Button Create(Joystick js, int buttonid)
+    {
+        int port = -1;
+        if(js != null)
+            port = js.getPort();
+
+        int newId = Constants.OI.getRemappedButton(port, buttonid);
+        if(newId == -1)
+            return new InvalidButton(0, buttonid);
+        else
+            return new JoystickButton(js, buttonid);
+    }
+
+    /* we don't extend JoystickButton because the super is always
+     * called and this is the source of some spewage when missing.
+     */
+    private static class InvalidButton extends Button
+    {
+        public InvalidButton(int port, int button) 
+        {
+        }
+
+        /* overriding core Trigger methods gets us most of the way since Button
+         * is a thin vaneer atop Trigger
+         */
+        @Override
+        public Trigger whenActive(final Command toRun, boolean inter)
+        {
+            // no-op
+            return this;
+        }
+
+        @Override
+        public Trigger whileActiveContinuous(final Command toRun, boolean inter)
+        {
+            // no-op
+            return this;
+        }
+
+        @Override
+        public Trigger whileActiveOnce(final Command toRun, boolean inter)
+        {
+            // no-op
+            return this;
+        }
+
+        @Override
+        public Button whenInactive(final Command toRun, boolean intr)
+        {
+            // no-op
+            return this;
+        }
+
+        @Override
+        public Button toggleWhenActive(final Command toRun, boolean intr)
+        {
+            // no-op
+            return this;
+        }
+
+        @Override
+        public Button cancelWhenActive(final Command toRun)
+        {
+            // no-op
+            return this;
+        }
+
+    }
+}


### PR DESCRIPTION
Here's (change 820b68b) is an example implementation of configurable ButtonBindings that would allow us to express the differences, say, between main robot, testplatform 1, etc.  From RobotContainer's POV, this seems to have very little negative impact.  The config behavior is currently in a combination of Constants.OI and ButtonFactory.

I've done this work in a separate branch so it's really easy for me to punt.  You can express the intent to punt by simply canceling this pull request.

Alternatively if this capability might be useful go ahead and accept the pull request.

Seems pretty harmless to me, but you never know.  I have *not* had the opportunity to validate on a real device.
