### PR TITLE
LED subsystem now uses jSerialComm for named serial connection.

### DIFF
--- a/src/main/java/com/spartronics4915/frc2020/Robot.java
+++ b/src/main/java/com/spartronics4915/frc2020/Robot.java
@@ -74,6 +74,9 @@ public class Robot extends TimedRobot
 
         SmartDashboard.putString("CANBusStatus", CANCounter.getStatusMessage());
         Logger.info("CAN bus status: " + CANCounter.getStatusMessage());
+
+        // print out available serial ports for information
+        LED.getInstance().enumerateAvailablePorts();
     }
 
     @Override
@@ -105,7 +108,6 @@ public class Robot extends TimedRobot
     @Override
     public void disabledInit()
     {
-        // TODO: verify call to DISABLED bling state
         Logger.notice("@disabledInit: Requested BlingState.BLING_COMMAND_DISABLED");
         LED.getInstance().setBlingState(BlingState.BLING_COMMAND_DISABLED);
     }
@@ -127,6 +129,8 @@ public class Robot extends TimedRobot
         {
             mAutonomousCommand.schedule();
         }
+
+        LED.getInstance().setBlingState(BlingState.BLING_COMMAND_AUTOMODE);
     }
 
     /**
@@ -144,6 +148,8 @@ public class Robot extends TimedRobot
         {
             mAutonomousCommand.cancel();
         }
+
+        LED.getInstance().setBlingState(BlingState.BLING_COMMAND_STARTUP);
     }
 
     /**
@@ -158,6 +164,8 @@ public class Robot extends TimedRobot
     public void testInit()
     {
         CommandScheduler.getInstance().cancelAll();
+
+        LED.getInstance().setBlingState(BlingState.BLING_COMMAND_STARTUP);
     }
 
     /**


### PR DESCRIPTION
* LED subsystem lists out enumerated ports
* Successful communication w/ Arduino verified using Atlas along with hub+devices
* Robot.java prints out available ports during robotInit() for debugging
* Robot.java has LED states on robot init functions (auto, teleop, test)