### PR TITLE
Renamed CamToField to CoordSysMgr, misc cleanups

### DIFF
--- a/src/main/java/com/spartronics4915/frc2020/CamToField2020.java
+++ b/src/main/java/com/spartronics4915/frc2020/CamToField2020.java
@@ -79,7 +79,7 @@ public class CamToField2020 extends CameraToField
     // mount to robot ------------------------------------------------------
     // turret is mounted at robot back/center, up from ground
     // turret's x axis is opposite robot's 
-    private final Vec3 mMntPos = new Vec3(-15, 0, 8); 
+    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8);  // XXX: is 8 correct?
     private final Vec3 mMntAxis = Vec3.ZAxis;
     private final Affine3 mMntFlip = Affine3.fromRotation(180, this.mMntAxis);
 

--- a/src/main/java/com/spartronics4915/frc2020/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2020/Constants.java
@@ -1,5 +1,11 @@
 package com.spartronics4915.frc2020;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.revrobotics.ColorMatch;
 import com.spartronics4915.lib.hardware.motors.SensorModel;
 import com.spartronics4915.lib.hardware.motors.SpartronicsMax;
 import com.spartronics4915.lib.hardware.motors.SpartronicsMotor;
@@ -8,19 +14,28 @@ import com.spartronics4915.lib.math.twodim.geometry.Pose2d;
 import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
 import com.spartronics4915.lib.util.Logger;
 import com.spartronics4915.lib.util.TriFunction;
-import com.revrobotics.ColorMatch;
 
 import edu.wpi.first.wpilibj.util.Color;
 import edu.wpi.first.wpilibj.util.Units;
 
-import java.io.IOException;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.function.BiFunction;
-
 public final class Constants
 {
+    public static String sConfig;
+    static  // check our machine id so subsystems can support multiple configs
+    {
+        sConfig = "default";
+        Path machineIDPath = FileSystems.getDefault().getPath(System.getProperty("user.home"),
+            "machineid");
+        try
+        {
+            sConfig = Files.readString(machineIDPath).trim().toLowerCase();
+        }
+        catch (IOException e)
+        {
+        }
+        Logger.notice("Running on " + sConfig + " constants");
+    }
+
     public static final class Climber
     {
         public static final int kLiftMotorId = 5;
@@ -191,19 +206,7 @@ public final class Constants
         // Initialize blank fields that are robot-specific here
         static
         {
-            String config = "default";
-            Path machineIDPath = FileSystems.getDefault().getPath(System.getProperty("user.home"),
-                "machineid");
-            try
-            {
-                config = Files.readString(machineIDPath).trim().toLowerCase();
-            }
-            catch (IOException e)
-            {
-            }
-            Logger.notice("Running on " + config + " constants");
-
-            switch (config)
+            switch (sConfig)
             {
                 case "test chassis":
                     kTrackWidthMeters = Units.inchesToMeters(23.75);
@@ -267,18 +270,18 @@ public final class Constants
     public static final class Estimator
     {
         // XXX: consider whether to adopt CamToField2020, we currently
-        //  have competing implementations. Also, since the turret is
-        //  moving, there can't be a single offset of the camera to robot, 
-        //  right? (ie: we need camera orientation wrt turret and turrent
-        //  orientation wrt robot origin).
-        public static final Pose2d kSlamraToRobot = new Pose2d(Units.inchesToMeters(-6.4375), Units.inchesToMeters(10.625), Rotation2d.fromDegrees(90));//new Pose2d(-0.390525, 0, new Rotation2d());
-        public static final Pose2d kVisionToRobot = new Pose2d(0.390525, 0, Rotation2d.fromDegrees(0));
+        //  have competing implementations. 
+        // If new measurements for Vision or Turret mounting are obtained,
+        // please also update CoordSysMgr20202.java.
         public static final double kMeasurementCovariance = 0.001;
+        public static final Pose2d kSlamraToRobot = new Pose2d(Units.inchesToMeters(-6.4375), 
+                                                            Units.inchesToMeters(10.625), 
+                                                            Rotation2d.fromDegrees(90));
     }
 
     public static final class Vision
     {
-        /* Camera mount geometry is located in CamToField2020.java */
+        /* Camera+mount geometry is located in CamToField2020.java */
 
         /* Raspi/Vision server status on /Vision namespace ------------------*/
         public static final String kTurretTargetTable = "/Vision/Target";
@@ -305,6 +308,6 @@ public final class Constants
         public static final double[] kOpponentGoalCoords = {0, 67.5, kGoalHeight};
         public static final double[] kAllianceGoalCoords = {628, -67.5, kGoalHeight};
 
-        public static final int kLEDRelay = 0; // Relay, not DIO pin!!!
+        public static final int kLEDRelayPin = 0; // Relay, not DIO pin!!!
     }
 }

--- a/src/main/java/com/spartronics4915/frc2020/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2020/Constants.java
@@ -117,6 +117,7 @@ public final class Constants
         /** RPS */
         public static final double kFlywheelVelocityTolerance = 1.0;
         public static final double kMaxRPS = 90.0; // Reasonable guess
+        public static final double kMaxAngleDegrees = 30;
         public static final Rotation2d kMaxAngle = Rotation2d.fromDegrees(30.0);
 
         public static Pose2d goalLocation = null;

--- a/src/main/java/com/spartronics4915/frc2020/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2020/Constants.java
@@ -92,6 +92,8 @@ public final class Constants
         public static final int kTurretId = 8;
         public static final int kTurretPotentiometerId = 0; // Analog
 
+        // XXX: consider whether to adopt CamToField2020, we currently have 
+        // competing implementations.
         public static final Pose2d kRobotToTurret = new Pose2d(Units.inchesToMeters(-3.72), Units.inchesToMeters(5.264), Rotation2d.fromDegrees(180.0));
         
         // https://docs.wpilib.org/en/latest/docs/software/advanced-control/controllers/feedforward.html#simplemotorfeedforward
@@ -254,6 +256,8 @@ public final class Constants
 
     public static final class Estimator
     {
+        // XXX: consider whether to adopt CamToField2020, we currently
+        //  have competing implementations.
         public static final Pose2d kSlamraToRobot = new Pose2d(Units.inchesToMeters(-6.4375), Units.inchesToMeters(10.625), Rotation2d.fromDegrees(90));//new Pose2d(-0.390525, 0, new Rotation2d());
         public static final Pose2d kVisionToRobot = new Pose2d(0.390525, 0, Rotation2d.fromDegrees(0));
         public static final double kMeasurementCovariance = 0.001;

--- a/src/main/java/com/spartronics4915/frc2020/Constants.java
+++ b/src/main/java/com/spartronics4915/frc2020/Constants.java
@@ -94,8 +94,10 @@ public final class Constants
 
         // XXX: consider whether to adopt CamToField2020, we currently have 
         // competing implementations.
-        public static final Pose2d kRobotToTurret = new Pose2d(Units.inchesToMeters(-3.72), Units.inchesToMeters(5.264), Rotation2d.fromDegrees(180.0));
-        
+        public static final Pose2d kRobotToTurret = new Pose2d(Units.inchesToMeters(-3.72), 
+                                                    Units.inchesToMeters(5.264), 
+                                                    Rotation2d.fromDegrees(180.0));
+    
         // https://docs.wpilib.org/en/latest/docs/software/advanced-control/controllers/feedforward.html#simplemotorfeedforward
         public static final double kP = 0.05;
         public static final double kS = 0.0286; // 0.0654;
@@ -261,7 +263,10 @@ public final class Constants
     public static final class Estimator
     {
         // XXX: consider whether to adopt CamToField2020, we currently
-        //  have competing implementations.
+        //  have competing implementations. Also, since the turret is
+        //  moving, there can't be a single offset of the camera to robot, 
+        //  right? (ie: we need camera orientation wrt turret and turrent
+        //  orientation wrt robot origin).
         public static final Pose2d kSlamraToRobot = new Pose2d(Units.inchesToMeters(-6.4375), Units.inchesToMeters(10.625), Rotation2d.fromDegrees(90));//new Pose2d(-0.390525, 0, new Rotation2d());
         public static final Pose2d kVisionToRobot = new Pose2d(0.390525, 0, Rotation2d.fromDegrees(0));
         public static final double kMeasurementCovariance = 0.001;

--- a/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
+++ b/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
@@ -1,7 +1,6 @@
 package com.spartronics4915.frc2020;
 
 import com.spartronics4915.lib.math.threedim.*;
-import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
 
 /**
  * CamToField2020 extends CameraToField. See coordinate system comments
@@ -77,9 +76,16 @@ public class CoordSysMgr2020 extends CoordSysMgr
     private final Vec3 mCamFlipZ = new Vec3(-1, 0, 0);  // cam +z is turret's -x
 
     // mount to robot ------------------------------------------------------
-    // turret is mounted at robot back (3.72 inches behind robot center)
+    // turret is mounted at robot back/center, up from ground
     // turret's x axis is opposite robot's 
-    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8); 
+    // NB: this mMntPos is derived from Constants.kRobotToTurret.
+    // We interpret this as:  3.72 inches behind and 5.264 inches
+    // to the right of the robot's origin. Current twodim code doesn't
+    // consider the z origin (offset from floor). This becomes important
+    // as we consider the camera "pitch"/tilt. Currently the height of
+    // the turret origin relative to the robot origin (on the carpet), is
+    // only guessed to be 8 inches.
+    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8);
     private final Vec3 mMntAxis = Vec3.ZAxis;
     private final Affine3 mMntFlip = Affine3.fromRotation(180, this.mMntAxis);
 

--- a/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
+++ b/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
@@ -55,7 +55,7 @@ import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
  *       
  */
 
-public class CamToField2020 extends CameraToField
+public class CoordSysMgr2020 extends CoordSysMgr
 {
     // camera to mount -----------------------------------------------------
     // camTilt represents the amount the camera is pointed up, measured in
@@ -77,9 +77,9 @@ public class CamToField2020 extends CameraToField
     private final Vec3 mCamFlipZ = new Vec3(-1, 0, 0);  // cam +z is turret's -x
 
     // mount to robot ------------------------------------------------------
-    // turret is mounted at robot back/center, up from ground
+    // turret is mounted at robot back (3.72 inches behind robot center)
     // turret's x axis is opposite robot's 
-    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8);  // XXX: is 8 correct?
+    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8); 
     private final Vec3 mMntAxis = Vec3.ZAxis;
     private final Affine3 mMntFlip = Affine3.fromRotation(180, this.mMntAxis);
 
@@ -87,7 +87,7 @@ public class CamToField2020 extends CameraToField
      * Constructor for the CamToField pipeline for 2020 robot.  Presumably
      * we need only a single instance.
      */
-    public CamToField2020()
+    public CoordSysMgr2020()
     {
         /* NB: see CamToFieldTests for validation. The file is located in
         * the tests subtree (rather than here) to prevent pollution of
@@ -100,16 +100,16 @@ public class CamToField2020 extends CameraToField
         Affine3 camOffset = Affine3.fromTranslation(mCamPos);
         Affine3 camToMount = Affine3.concatenate(camOffset, camRot);
         this.setCamToMount(camToMount);
-        this.updateTurretAngle(new Rotation2d());
+        this.updateTurretAngle(0);
     }
 
     /**
      * Called periodically to update the camToField conversion.
-     * @param rot - turret angle; 0 is "straight"
+     * @param angle - turret angle; 0 is "straight" (degrees)
      */
-    public void updateTurretAngle(Rotation2d rot)
+    public void updateTurretAngle(double angle)
     {
-        Affine3 m2rAim = Affine3.fromRotation(rot.getDegrees(), Vec3.ZAxis);
+        Affine3 m2rAim = Affine3.fromRotation(angle, Vec3.ZAxis);
         Affine3 m2rRot = Affine3.concatenate(mMntFlip, m2rAim);
         Affine3 m2rOffset = Affine3.fromTranslation(mMntPos);
         Affine3 mntToRobot = Affine3.concatenate(m2rOffset, m2rRot);

--- a/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
+++ b/src/main/java/com/spartronics4915/frc2020/CoordSysMgr2020.java
@@ -3,10 +3,11 @@ package com.spartronics4915.frc2020;
 import com.spartronics4915.lib.math.threedim.*;
 
 /**
- * CamToField2020 extends CameraToField. See coordinate system comments
- * therein. We extend CameraToField with the season-specific mounting of
- * the camera onto the robot.
- * 
+ * CoordSysMgr2020 extends CoordSysMgr. See comments therein. We extend 
+ * CoordSysMgr with the season-specific mounting of the camera onto the robot.
+ */
+
+ /* 
  * Atm: we envision two scenarios:
  * 
  * 1. camera mounted on moving launcher turret
@@ -63,31 +64,31 @@ public class CoordSysMgr2020 extends CoordSysMgr
     // camera with a mark.  Measure the distance from height of the mark
     // to the camera origin.  Measure the distance from the wall.  Use
     // degrees(atan2(mark, dist)) to compute the tilt angle.
-    private final double mCamTilt = 15; // if you change this also change
+    public static final double kCamTilt = 15; 
 
     // camPos represents offset of camera's origin relative to turret origin.
     // (measured in inches).  Camera origin is the center of the focal point.
     // So we do expect some z offset as well as x.
-    private final Vec3 mCamPos = new Vec3(0, -12, 0); 
+    public static final Vec3 kCamPos = new Vec3(0, -12, 0); 
 
     // camFlips maps camera axes to mount axes. eg: cam x is turret -y (above)
-    private final Vec3 mCamFlipX = new Vec3(0, -1, 0);  // cam +x is turret's -y
-    private final Vec3 mCamFlipY = new Vec3(0, 0, 1);   // cam +y is turret's +z
-    private final Vec3 mCamFlipZ = new Vec3(-1, 0, 0);  // cam +z is turret's -x
+    public static final Vec3 kCamFlipX = new Vec3(0, -1, 0);  // cam +x is turret's -y
+    public static final Vec3 kCamFlipY = new Vec3(0, 0, 1);   // cam +y is turret's +z
+    public static final Vec3 kCamFlipZ = new Vec3(-1, 0, 0);  // cam +z is turret's -x
 
     // mount to robot ------------------------------------------------------
-    // turret is mounted at robot back/center, up from ground
-    // turret's x axis is opposite robot's 
-    // NB: this mMntPos is derived from Constants.kRobotToTurret.
+    // - Turret is mounted at robot back+right, up from ground
+    // - Turret's x axis is opposite robot's 
+    // NB: this mMntPos is also in Constants.Launcher.kRobotToTurret.
     // We interpret this as:  3.72 inches behind and 5.264 inches
     // to the right of the robot's origin. Current twodim code doesn't
     // consider the z origin (offset from floor). This becomes important
     // as we consider the camera "pitch"/tilt. Currently the height of
     // the turret origin relative to the robot origin (on the carpet), is
     // only guessed to be 8 inches.
-    private final Vec3 mMntPos = new Vec3(-3.72, 5.264, 8);
-    private final Vec3 mMntAxis = Vec3.ZAxis;
-    private final Affine3 mMntFlip = Affine3.fromRotation(180, this.mMntAxis);
+    public static final Vec3 kMntPos = new Vec3(-3.72, 5.264, 8);
+    public static final Vec3 kMntAxis = Vec3.ZAxis;
+    public static final Affine3 kMntFlip = Affine3.fromRotation(180, kMntAxis);
 
     /**
      * Constructor for the CamToField pipeline for 2020 robot.  Presumably
@@ -95,29 +96,32 @@ public class CoordSysMgr2020 extends CoordSysMgr
      */
     public CoordSysMgr2020()
     {
-        /* NB: see CamToFieldTests for validation. The file is located in
+        /* NB: see CoordSysMgrTest for validation. The file is located in
         * the tests subtree (rather than here) to prevent pollution of
         * production jar by tests.
         */
         super();
-        Affine3 camFlips = Affine3.fromAxes(mCamFlipX, mCamFlipY, mCamFlipZ);
-        Affine3 camTilt = Affine3.fromRotation(mCamTilt, Vec3.XAxis);
+        Affine3 camFlips = Affine3.fromAxes(kCamFlipX, kCamFlipY, kCamFlipZ);
+        Affine3 camTilt = Affine3.fromRotation(kCamTilt, Vec3.XAxis);
         Affine3 camRot = Affine3.concatenate(camFlips, camTilt);
-        Affine3 camOffset = Affine3.fromTranslation(mCamPos);
+        Affine3 camOffset = Affine3.fromTranslation(kCamPos);
         Affine3 camToMount = Affine3.concatenate(camOffset, camRot);
         this.setCamToMount(camToMount);
         this.updateTurretAngle(0);
     }
 
     /**
-     * Called periodically to update the camToField conversion.
+     * Updates the mountToRobot coordinate system conversion. Should
+     * reflect the current state of the turret angle.  This plus the
+     * Robot's field pose is sufficient to calculate the conversion
+     * of Vision targets into field targets. 
      * @param angle - turret angle; 0 is "straight" (degrees)
      */
     public void updateTurretAngle(double angle)
     {
         Affine3 m2rAim = Affine3.fromRotation(angle, Vec3.ZAxis);
-        Affine3 m2rRot = Affine3.concatenate(mMntFlip, m2rAim);
-        Affine3 m2rOffset = Affine3.fromTranslation(mMntPos);
+        Affine3 m2rRot = Affine3.concatenate(kMntFlip, m2rAim);
+        Affine3 m2rOffset = Affine3.fromTranslation(kMntPos);
         Affine3 mntToRobot = Affine3.concatenate(m2rOffset, m2rRot);
         this.setMountToRobot(mntToRobot);
     }

--- a/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
@@ -59,6 +59,7 @@ public class RobotContainer
     private final Drive mDrive;
     private final RamseteTracker mRamseteController = new RamseteTracker(2, 0.7);
     private final RobotStateEstimator mStateEstimator;
+    private final CoordSysMgr2020 mCamToField;
     private final TrajectoryContainer.AutoMode[] mAutoModes;
 
     /* subsystem commands */
@@ -99,6 +100,7 @@ public class RobotContainer
             () -> mStateEstimator.stop(), mStateEstimator);
         mStateEstimator.setDefaultCommand(slamraCommand);
         mStateEstimator.resetRobotStateMaps(new Pose2d());
+        mCamToField = new CoordSysMgr2020();
 
         mAutoModes = TrajectoryContainer.getAutoModes(mStateEstimator, mDrive, mRamseteController);
         String autoModeList = Arrays.stream(mAutoModes).map((m) -> m.name)
@@ -110,13 +112,14 @@ public class RobotContainer
         mLauncher = new Launcher();
         mPanelRotator = new PanelRotator();
         mLED = LED.getInstance();
-        mVision = new Vision(mStateEstimator, mLauncher);
+        mVision = new Vision(mStateEstimator, mCamToField, mLauncher);
 
         mClimberCommands = new ClimberCommands();
         mIntakeCommands = new IntakeCommands(mIntake);
         mIndexerCommands = new IndexerCommands(mIndexer);
         mLauncherCommands = new LauncherCommands(mLauncher, mIndexerCommands,
-                                mStateEstimator.getEncoderRobotStateMap());
+                                mStateEstimator.getEncoderRobotStateMap(),
+                                mCamToField);
         mPanelRotatorCommands = new PanelRotatorCommands();
         mSuperstructureCommands = new SuperstructureCommands(mLauncherCommands,
                                                           mIntakeCommands,

--- a/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
@@ -1,28 +1,28 @@
 package com.spartronics4915.frc2020;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.spartronics4915.frc2020.TrajectoryContainer.Destination;
-import com.spartronics4915.frc2020.commands.*;
-import com.spartronics4915.frc2020.subsystems.*;
+import com.spartronics4915.frc2020.commands.ClimberCommands;
+import com.spartronics4915.frc2020.commands.DriveCommands;
+import com.spartronics4915.frc2020.commands.IndexerCommands;
+import com.spartronics4915.frc2020.commands.IntakeCommands;
+import com.spartronics4915.frc2020.commands.LauncherCommands;
+import com.spartronics4915.frc2020.commands.PanelRotatorCommands;
+import com.spartronics4915.frc2020.commands.SuperstructureCommands;
+import com.spartronics4915.frc2020.subsystems.Climber;
+import com.spartronics4915.frc2020.subsystems.Drive;
+import com.spartronics4915.frc2020.subsystems.Indexer;
+import com.spartronics4915.frc2020.subsystems.Intake;
+import com.spartronics4915.frc2020.subsystems.LED;
+import com.spartronics4915.frc2020.subsystems.Launcher;
+import com.spartronics4915.frc2020.subsystems.PanelRotator;
+import com.spartronics4915.frc2020.subsystems.Vision;
 import com.spartronics4915.lib.hardware.sensors.T265Camera;
 import com.spartronics4915.lib.hardware.sensors.T265Camera.CameraJNIException;
 import com.spartronics4915.lib.math.twodim.control.RamseteTracker;
 import com.spartronics4915.lib.math.twodim.geometry.Pose2d;
-import com.spartronics4915.lib.math.twodim.geometry.Pose2dWithCurvature;
-import com.spartronics4915.lib.math.twodim.geometry.Rectangle2d;
-import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
-import com.spartronics4915.lib.math.twodim.geometry.Translation2d;
-import com.spartronics4915.lib.math.twodim.trajectory.constraints.TimingConstraint;
-import com.spartronics4915.lib.math.twodim.trajectory.constraints.VelocityLimitRegionConstraint;
-import com.spartronics4915.lib.math.twodim.trajectory.types.TimedTrajectory;
-import com.spartronics4915.lib.subsystems.drive.CharacterizeDriveBaseCommand;
-import com.spartronics4915.lib.subsystems.drive.TrajectoryTrackerCommand;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateEstimator;
-import com.spartronics4915.lib.subsystems.estimator.RobotStateMap;
 import com.spartronics4915.lib.util.Kinematics;
 import com.spartronics4915.lib.util.Logger;
 
@@ -30,11 +30,8 @@ import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import edu.wpi.first.wpilibj.util.Units;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.StartEndCommand;
-import edu.wpi.first.wpilibj2.command.Subsystem;
-import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 public class RobotContainer
@@ -55,7 +52,6 @@ public class RobotContainer
     private final Drive mDrive;
     private final RamseteTracker mRamseteController = new RamseteTracker(2, 0.7);
     private final RobotStateEstimator mStateEstimator;
-    private final CoordSysMgr2020 mCamToField;
     private final TrajectoryContainer.AutoMode[] mAutoModes;
 
     /* subsystem commands */
@@ -95,7 +91,6 @@ public class RobotContainer
             () -> mStateEstimator.stop(), mStateEstimator);
         mStateEstimator.setDefaultCommand(slamraCommand);
         mStateEstimator.resetRobotStateMaps(new Pose2d());
-        mCamToField = new CoordSysMgr2020();
 
         mAutoModes = TrajectoryContainer.getAutoModes(mStateEstimator, mDrive, mRamseteController);
         String autoModeList = Arrays.stream(mAutoModes).map((m) -> m.name)
@@ -112,7 +107,7 @@ public class RobotContainer
         mLauncher = new Launcher();
         mPanelRotator = new PanelRotator();
         mLED = LED.getInstance();
-        mVision = new Vision(mStateEstimator, mCamToField, mLauncher);
+        mVision = new Vision(mStateEstimator, mLauncher);
 
         /* constructing subsystem commands */
         mClimberCommands = new ClimberCommands(mClimber);
@@ -120,8 +115,7 @@ public class RobotContainer
         mIntakeCommands = new IntakeCommands(mIntake);
         mIndexerCommands = new IndexerCommands(mIndexer);
         mLauncherCommands = new LauncherCommands(mLauncher, mIndexerCommands,
-                                mStateEstimator.getEncoderRobotStateMap(),
-                                mCamToField);
+                                mStateEstimator.getEncoderRobotStateMap());
         mPanelRotatorCommands = new PanelRotatorCommands(mPanelRotator);
         mSuperstructureCommands = new SuperstructureCommands(mIndexerCommands, 
                                             mIntakeCommands, mLauncherCommands);

--- a/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
+++ b/src/main/java/com/spartronics4915/frc2020/RobotContainer.java
@@ -73,7 +73,6 @@ public class RobotContainer
     private final Joystick mJoystick;
     private final Joystick mButtonBoard;
 
-
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
      */
@@ -116,8 +115,7 @@ public class RobotContainer
         mClimberCommands = new ClimberCommands();
         mIntakeCommands = new IntakeCommands(mIntake);
         mIndexerCommands = new IndexerCommands(mIndexer);
-        mLauncherCommands = new LauncherCommands(mLauncher, mIndexer, 
-                                mIndexerCommands,
+        mLauncherCommands = new LauncherCommands(mLauncher, mIndexerCommands,
                                 mStateEstimator.getEncoderRobotStateMap());
         mPanelRotatorCommands = new PanelRotatorCommands();
         mSuperstructureCommands = new SuperstructureCommands(mLauncherCommands,

--- a/src/main/java/com/spartronics4915/frc2020/commands/DriveCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/DriveCommands.java
@@ -1,7 +1,6 @@
 package com.spartronics4915.frc2020.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj.Joystick;
 
 import com.spartronics4915.frc2020.Constants;
@@ -41,9 +40,25 @@ public class DriveCommands
         @Override
         public void execute()
         {
-            mDrive.arcadeDrive(
-                (mInverted ? -1 : 1) * (mSlow ? Constants.Drive.kSlowModeMultiplier : 1) * mJoystick.getY(),
-                (mInverted ? -1 : 1) * (mSlow ? Constants.Drive.kSlowModeMultiplier : 1) * mJoystick.getX());
+            // before:
+            // (mInverted ? -1 : 1) * (mSlow ? Constants.Drive.kSlowModeMultiplier : 1) * mJoystick.getY(),
+            // (mInverted ? -1 : 1) * (mSlow ? Constants.Drive.kSlowModeMultiplier : 1) * mJoystick.getX());
+
+            // after (with helpful comments)
+            double x = mJoystick.getX();
+            double y = mJoystick.getY(); 
+            y = -1;  // reverse the sense of joystick y, fwd should be positive
+            if(mSlow)
+            {
+                x *= Constants.Drive.kSlowModeMultiplier;
+                y *= Constants.Drive.kSlowModeMultiplier;
+            }
+            if(mInverted)
+            {
+                x *= -1;
+                y *= -1;
+            }
+            mDrive.arcadeDrive(y, x);
         }
     }
 
@@ -68,14 +83,11 @@ public class DriveCommands
         @Override
         public boolean isFinished()
         {
-            return true;
+           return true;
         }
     }
 
     /**
-     * Toggles the mSlow boolean through the bitwise XOR operator. Gross!
-     * (a much more readable way would be boolean = !boolean)
-     * <p>
      * Instantly ends, and goes back to the default TeleOpCommand.
      */
     public class ToggleSlow extends CommandBase
@@ -88,7 +100,7 @@ public class DriveCommands
         @Override
         public void initialize()
         {
-            mSlow ^= true;
+            mSlow = !mSlow;
         }
 
         @Override
@@ -99,9 +111,6 @@ public class DriveCommands
     }
 
     /**
-     * Toggles the mInverted boolean through the bitwise XOR operator. Gross!
-     * (a much more readable way would be boolean = !boolean)
-     * <p>
      * Instantly ends, and goes back to the default TeleOpCommand.
      */
     public class ToggleInverted extends CommandBase
@@ -114,7 +123,7 @@ public class DriveCommands
         @Override
         public void initialize()
         {
-            mInverted ^= true;
+            mInverted = !mInverted;
         }
 
         @Override

--- a/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
@@ -23,16 +23,21 @@ public class LauncherCommands
     private final Indexer mIndexer;
     private final IndexerCommands mIndexerCommands;
     private final RobotStateMap mStateMap;
-    private final Pose2d mTarget;
+    private final Pose2d mMatchTarget;
 
-    public LauncherCommands(Launcher launcher, Indexer indexer, 
-                    IndexerCommands indexerCommands, RobotStateMap stateMap)
+    public LauncherCommands(Launcher launcher, IndexerCommands indexerCommands, 
+                            RobotStateMap stateMap)
     {
         mLauncher = launcher;
-        mIndexer = indexer;
         mIndexerCommands = indexerCommands;
+        mIndexer = mIndexerCommands.getIndexer();
         mStateMap = stateMap;
-        mTarget = null;
+        // our target is always on the opposite side of the field.  This
+        // works for both Alliances since the field is symmetric and we
+        // use the same coordinate system (rotated by 180) on the Dashboard.
+        mMatchTarget = new Pose2d(Constants.Vision.kAllianceGoalCoords[0],
+                                  Constants.Vision.kAllianceGoalCoords[0],
+                                  Rotation2d.fromDegrees(180));
     }
 
     public Launcher getLauncher()
@@ -50,6 +55,8 @@ public class LauncherCommands
         }
 
         // Called every time the scheduler runs while the command is scheduled.
+        // Default isFinished (true) is okay since we assume we'll be 
+        // interrupted by button-release.
         @Override
         public void execute()
         {
@@ -58,7 +65,8 @@ public class LauncherCommands
         }
 
         @Override
-        public void end(boolean interrupted) {
+        public void end(boolean interrupted)
+        {
             mLauncher.stopTurret();
         }
     }

--- a/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
@@ -233,7 +233,7 @@ public class LauncherCommands
         public void execute()
         {
             mLauncher.turnTurret(Rotation2d.fromDegrees((double) mLauncher.dashboardGetNumber("turretAngleSlider", 0)));
-            double dist = (double) mLauncher.dashboardGetNumber("targetDistance", 120);
+            double dist = (double) mLauncher.dashboardGetNumber("targetDistanceSlider", 120);
             mLauncher.runFlywheel(mLauncher.calcRPS(dist));
             mLauncher.adjustHood(mLauncher.calcPitch(dist));
         }

--- a/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
@@ -144,8 +144,8 @@ public class LauncherCommands
 
 
     /**
-     * return the distance to the tracked target.  If the target is within
-     * our "reach", we adjust both hood and turret angle.
+     * return the distance (in meters) to the tracked target.  If the target 
+     * is within our field of view, we adjust both hood and turret angle.
      */
     private double trackTargetAlt()
     {
@@ -156,7 +156,12 @@ public class LauncherCommands
 
         Vec3 targetPointInMnt = mCoordSysMgr.fieldPointToMount(mMatchTargetInches);
         double angle = targetPointInMnt.angleOnXYPlane();
-        double dist = targetPointInMnt.length();
+        double dist = Units.inchesToMeters(targetPointInMnt.length());
+        if(angle > 180)
+        {
+            // [0-360] -> (-180, 180]
+            angle = -(360 - angle);
+        }
         if (Math.abs(angle) < Constants.Launcher.kMaxAngleDegrees)
         {
             mLauncher.adjustHood(mLauncher.calcPitch(dist));

--- a/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/LauncherCommands.java
@@ -3,11 +3,14 @@ package com.spartronics4915.frc2020.commands;
 import java.util.function.BooleanSupplier;
 
 import com.spartronics4915.frc2020.Constants;
+import com.spartronics4915.frc2020.CoordSysMgr2020;
 import com.spartronics4915.frc2020.commands.IndexerCommands.LoadToLauncher;
 import com.spartronics4915.frc2020.subsystems.Indexer;
 import com.spartronics4915.frc2020.subsystems.Launcher;
 import com.spartronics4915.lib.math.twodim.geometry.Pose2d;
 import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
+import com.spartronics4915.lib.math.threedim.Vec3;
+import com.spartronics4915.lib.util.Units;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateMap;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -22,21 +25,31 @@ public class LauncherCommands
     private final Launcher mLauncher;
     private final Indexer mIndexer;
     private final IndexerCommands mIndexerCommands;
+    final CoordSysMgr2020 mCoordSysMgr;
     private final RobotStateMap mStateMap;
-    private final Pose2d mMatchTarget;
+    private final Pose2d mMatchTargetMeters;
+    private final Vec3 mMatchTargetInches;
 
     public LauncherCommands(Launcher launcher, IndexerCommands indexerCommands, 
-                            RobotStateMap stateMap)
+                            RobotStateMap stateMap, CoordSysMgr2020 csmgr)
     {
         mLauncher = launcher;
         mIndexerCommands = indexerCommands;
         mIndexer = mIndexerCommands.getIndexer();
         mStateMap = stateMap;
+        mCoordSysMgr = csmgr;
         // our target is always on the opposite side of the field.  This
         // works for both Alliances since the field is symmetric and we
         // use the same coordinate system (rotated by 180) on the Dashboard.
-        mMatchTarget = new Pose2d(Constants.Vision.kAllianceGoalCoords[0],
-                                  Constants.Vision.kAllianceGoalCoords[0],
+        // (almost, since RSM is meters and dashboard is inches).
+        mMatchTargetInches = new Vec3(
+                                Constants.Vision.kAllianceGoalCoords[0],
+                                Constants.Vision.kAllianceGoalCoords[1],
+                                0); // on ground/robot origin
+
+        mMatchTargetMeters = new Pose2d(
+            Units.inchesToMeters(Constants.Vision.kAllianceGoalCoords[0]),
+            Units.inchesToMeters(Constants.Vision.kAllianceGoalCoords[1]),
                                   Rotation2d.fromDegrees(180));
     }
 
@@ -60,7 +73,7 @@ public class LauncherCommands
         @Override
         public void execute()
         {
-            double distance = trackTarget(mTarget);
+            double distance = trackTarget();
             mLauncher.runFlywheel(mLauncher.calcRPS(distance));
         }
 
@@ -73,9 +86,7 @@ public class LauncherCommands
 
     public class TrackPassively extends CommandBase
     {
-        Pose2d mTarget;
-
-        public TrackPassively(Pose2d target)
+        public TrackPassively()
         {
             addRequirements(mLauncher);
         }
@@ -90,7 +101,7 @@ public class LauncherCommands
         @Override
         public void execute()
         {
-            trackTarget(mTarget);
+            trackTarget();
         }
     }
 
@@ -117,20 +128,39 @@ public class LauncherCommands
     /**
      * @return Distance to the target in meters
      */
-    private double trackTarget(Pose2d target)
+    private double trackTarget()
     {
         Pose2d fieldToTurret = mStateMap.getLatestFieldToVehicle()
             .transformBy(Constants.Launcher.kRobotToTurret);
-        Pose2d turretToTarget = fieldToTurret.inFrameReferenceOf(target);
+        Pose2d turretToTarget = fieldToTurret.inFrameReferenceOf(mMatchTargetMeters);
         Rotation2d fieldAnglePointingToTarget = new Rotation2d(
                                 turretToTarget.getTranslation().getX(), 
                                 turretToTarget.getTranslation().getY(), 
                                 true);
         Rotation2d turretAngle = fieldAnglePointingToTarget.rotateBy(fieldToTurret.getRotation().inverse());
-        double distance = mTarget.distance(fieldToTurret);
+        double distance = mMatchTargetMeters.distance(fieldToTurret);
         mLauncher.adjustHood(mLauncher.calcPitch(distance));
         mLauncher.turnTurret(turretAngle);
         return distance;
+    }
+
+    private double trackTargetAlt()
+    {
+        // We assume that mCoordSysMgr is up-to-date - this includes
+        //  - robot's pose
+        //  - turret rotation
+        // 
+        // Compute the vector from turret origin on field to target
+        // 
+        Vec3 targetPointInMnt = mCoordSysMgr.fieldPointToMount(mMatchTargetInches);
+        double angle = targetPointInMnt.angleOnXYPlane();
+        double dist = targetPointInMnt.length();
+        if(angle > -45 && angle < 45)
+        {
+            mLauncher.adjustHood(mLauncher.calcPitch(dist));
+            mLauncher.turnTurret(angle);
+        }
+        return dist;
     }
 
     /*

--- a/src/main/java/com/spartronics4915/frc2020/commands/VisionCommands.java
+++ b/src/main/java/com/spartronics4915/frc2020/commands/VisionCommands.java
@@ -1,0 +1,106 @@
+package com.spartronics4915.frc2020.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+
+import com.spartronics4915.frc2020.Constants;
+import com.spartronics4915.frc2020.subsystems.Vision;
+
+/**
+ * Very little going on here currently:
+ *  1. (driver or autonomous) control over VisionLED releay
+ *  2. default behavior listening for dashboard request to change LED state.
+ * 
+ * NB: turret angle updates are under the control of LauncherCommands.
+ *   we assume that the updated turret angle is correctly delivered
+ *   to the CoordSysMgr.
+ */
+public class VisionCommands
+{
+    private Vision mVision;
+
+    public VisionCommands(Vision subsys)
+    {
+        mVision = subsys;
+        mVision.setDefaultCommand(new DefaultCommand());
+    }
+
+    public static enum LEDStateChange
+    {
+        kOff,
+        kOn,
+        kToggle
+    };
+
+    /**
+     * An instant command that can turn on, off or toggle the VisionLED relay.
+     * This probably should be invoked automatically when odometry determines
+     * that we're in a place where vision targeting is enabled.
+     * 
+     * XXX: perhaps this should be the central control for acquisition:
+     *   ie: light is off, we could notify raspi to rest 
+     */
+    public class SetLEDRelay extends InstantCommand
+    {
+        LEDStateChange mStateChange;
+        public SetLEDRelay(LEDStateChange c)
+        {
+            super(); 
+            // NB: I think it's legit to say 'no subsystem requirements'.
+            // since we're the only one who cares about this relay.
+            // Now we won't unschedule our default command on each toggle.
+            mStateChange = c;
+        }
+
+        @Override
+        public void initialize()
+        {
+            // this is where InstantCommand does its thing
+            boolean oldstate = mVision.isLEDOn(), newstate;
+            switch(mStateChange)
+            {
+            case kOff:
+                newstate = false;
+                break;
+            case kOn:
+                newstate = true;
+                break;
+            case kToggle:
+            default:
+                newstate = !oldstate;
+                break;
+            }
+            mVision.setLED(newstate);
+            mVision.dashboardPutBoolean(Constants.Vision.kLEDRelayKey, newstate);
+        }
+    }
+
+    /**
+     * We listen for changes to the relay state nettab value - possibly
+     * changed by dashboard or even raspi vision.
+     */
+    private class DefaultCommand extends CommandBase
+    {
+        public DefaultCommand()
+        {
+            this.addRequirements(mVision);
+        }
+
+        @Override
+        public void execute()
+        {
+            // synchronize mLEDRelay with LEDRelay network table value.
+            boolean newstate = mVision.dashboardGetBoolean(Constants.Vision.kLEDRelayKey, true);
+            boolean oldstate = mVision.isLEDOn();
+            if(newstate != oldstate)
+                mVision.setLED(newstate);
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return false; // for clarity, we're always in this mode
+        }
+    }
+
+}

--- a/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
@@ -144,7 +144,7 @@ public class Launcher extends SpartronicsSubsystem
 
     /**
      * Rotates turret to a specific angle relative to the home position
-     * @param absoluteAngle Angle in degrees you want to turn the turret relative to the home position
+     * @param absoluteAngle Rotation2d expressing directed turret direction
      */
     public void turnTurret(Rotation2d absoluteAngle)
     {
@@ -152,6 +152,15 @@ public class Launcher extends SpartronicsSubsystem
         double output = mTurretPIDController.calculate(mTurretEncoder.getPosition(),
             Util.limit(absoluteAngle.getDegrees(), Constants.Launcher.kMaxAngle.getDegrees()));
         mTurretMotor.setDutyCycle(output);
+    }
+
+    /**
+     * Rotates turret to a specific angle relative to the home position
+     * @param absoluteAngle Angle in degrees you want to turn the turret relative to the home position
+     */
+    public void turnTurret(double angle)
+    {
+        this.turnTurret(Rotation2d.fromDegrees(angle));
     }
 
     /**

--- a/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
@@ -88,6 +88,7 @@ public class Launcher extends SpartronicsSubsystem
         mTargetTurretDirection = new Rotation2d();
 
         // One BAG motor for turret
+        // XXX: explain all these interesting constants.
         mTurretMotor = SpartronicsSRX.makeMotor(Constants.Launcher.kTurretId,
             SensorModel.fromMultiplier(Math.toDegrees(1.0 / 1024.0 / 11.75 / 20.0) * 2.0));// UNITS
                                                                                            // ARE
@@ -316,10 +317,9 @@ public class Launcher extends SpartronicsSubsystem
     @Override
     public void periodic()
     {
-        dashboardPutNumber("CurrentTurretAimAngle", getTurretDirection().getDegrees());
-
-        dashboardPutNumber("CurrentHoodAngle", getCurrentPitch().getDegrees());
-
-        dashboardPutNumber("CurrentFlywheelRPS", getCurrentRPS());
+        // nb: don't change these without changing Dashboard.
+        dashboardPutNumber("turretAngle", getTurretDirection().getDegrees());
+        dashboardPutNumber("hoodAngle", getCurrentPitch().getDegrees());
+        dashboardPutNumber("flywheelRPS", getCurrentRPS());
     }
 }

--- a/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/Launcher.java
@@ -317,7 +317,7 @@ public class Launcher extends SpartronicsSubsystem
     @Override
     public void periodic()
     {
-        // nb: don't change these without changing Dashboard.
+        // nb: don't change these nettable names without changing Dashboard.
         dashboardPutNumber("turretAngle", getTurretDirection().getDegrees());
         dashboardPutNumber("hoodAngle", getCurrentPitch().getDegrees());
         dashboardPutNumber("flywheelRPS", getCurrentRPS());

--- a/src/main/java/com/spartronics4915/frc2020/subsystems/Vision.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/Vision.java
@@ -1,28 +1,29 @@
 package com.spartronics4915.frc2020.subsystems;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Iterator;
-import java.util.Deque;
 import java.util.ArrayDeque;
-import edu.wpi.first.wpilibj2.command.CommandBase;
-import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.networktables.EntryListenerFlags;
-import edu.wpi.first.networktables.EntryNotification;
-import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.networktables.NetworkTableValue;
-import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.Relay.Value;
-import edu.wpi.first.wpilibj.Relay;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
 
 import com.spartronics4915.frc2020.Constants;
 import com.spartronics4915.frc2020.CoordSysMgr2020;
+import com.spartronics4915.lib.math.threedim.Vec3;
+import com.spartronics4915.lib.math.twodim.geometry.Pose2d;
+import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
+import com.spartronics4915.lib.math.twodim.geometry.Translation2d;
 import com.spartronics4915.lib.subsystems.SpartronicsSubsystem;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateEstimator;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateMap;
 import com.spartronics4915.lib.util.Units;
-import com.spartronics4915.lib.math.twodim.geometry.*;
-import com.spartronics4915.lib.math.threedim.*;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.EntryNotification;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.wpilibj.Relay;
+import edu.wpi.first.wpilibj.Relay.Value;
+import edu.wpi.first.wpilibj.Timer;
 
 /**
  * The Vision subsystem has these responsibilities 
@@ -88,7 +89,7 @@ public class Vision extends SpartronicsSubsystem
         this.mVisionEstimates = new ArrayDeque<RobotStateMap.State>();
         this.dashboardPutString(Constants.Vision.kStatusKey, "ready+waiting");
 
-        this.mLEDRelay = new Relay(Constants.Vision.kLEDRelay);
+        this.mLEDRelay = new Relay(Constants.Vision.kLEDRelayPin);
         mLEDRelay.set(Relay.Value.kOn);
         /// XXX: set the relay into a known/desired state!
         this.dashboardPutString(Constants.Vision.kLEDRelayKey, 

--- a/src/main/java/com/spartronics4915/frc2020/subsystems/Vision.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/Vision.java
@@ -12,11 +12,11 @@ import edu.wpi.first.networktables.EntryNotification;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.NetworkTableValue;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.Relay.Value;
 import edu.wpi.first.wpilibj.Relay;
 
 import com.spartronics4915.frc2020.Constants;
 import com.spartronics4915.frc2020.CoordSysMgr2020;
-import com.spartronics4915.frc2020.subsystems.Launcher;
 import com.spartronics4915.lib.subsystems.SpartronicsSubsystem;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateEstimator;
 import com.spartronics4915.lib.subsystems.estimator.RobotStateMap;
@@ -27,15 +27,19 @@ import com.spartronics4915.lib.math.threedim.*;
 /**
  * The Vision subsystem has these responsibilities 
  * 
- * - to listen to launcher for turret position
  * - to listen for vision coprocessor results and use it to estimate
- *   robot pose.
- * - to deliver a new robot state estimate into our RobotStateMap 
- *   (or ultimately deliver it to the RobotStateEstimator).
+ *   robot pose.  NB: this estimate is for a moment in the past associated
+ *   with the timestamp delivered with the vision target position.
  * - to turn on & off the vision LED
  * 
- * issues:
+ * We estimate the robot pose whenever we receive a vision target update from 
+ * raspi. This pose should be delivered to the CoordSysManager. 
+ * NB: there's an alternate operating mode where we the raspi-Vision 
+ * code computes/estimates robot pose. In that case our job would be
+ * to ensure that all required robot state would be presented to
+ * the network tables.
  */
+
 public class Vision extends SpartronicsSubsystem
 {
     /* public interfaces ------------------------------------*/
@@ -50,21 +54,19 @@ public class Vision extends SpartronicsSubsystem
     }
 
     /* member variables -------------------------------------*/
-    final RobotStateMap mOfficialRSM;
-    final CoordSysMgr2020 mCoordSysMgr;
-    final NetworkTableInstance mNetTab;
-    final Launcher mLauncher;
-    String mStatus;
-    List<VisionEvent> mListeners;
-    Deque<RobotStateMap.State> mVisionEstimates;
-    final Relay mLEDRelay; 
-    double mLastTurretAngle;
+    private final RobotStateMap mOfficialRSM;
+    private final CoordSysMgr2020 mCoordSysMgr;
+    private final NetworkTableInstance mNetTab;
+    private List<VisionEvent> mListeners;
+    private Deque<RobotStateMap.State> mVisionEstimates;
+    private final Relay mLEDRelay; 
+    private final Launcher mLauncher;
 
     /* NB: our targets are measured in inches, while RobotStateMap
      * operates in meters!
      */
-    final Vec3 mOurTarget = new Vec3(Constants.Vision.kAllianceGoalCoords);
-    final Vec3 mOpponentTarget = new Vec3(Constants.Vision.kOpponentGoalCoords);
+    private final Vec3 mOurTarget = new Vec3(Constants.Vision.kAllianceGoalCoords);
+    private final Vec3 mOpponentTarget = new Vec3(Constants.Vision.kOpponentGoalCoords);
 
     /**
      * Vision subsystem needs read-only access to RobotStateEstimator and
@@ -72,20 +74,18 @@ public class Vision extends SpartronicsSubsystem
      * @param rse
      * @param launcherSubsys
      */
-    public Vision(RobotStateEstimator rse, CoordSysMgr2020 coordSysMgr, 
-                    Launcher launcherSubsys)
+    public Vision(RobotStateEstimator rse, Launcher launcher)
     {
         this.mOfficialRSM = rse.getCameraRobotStateMap();
-        this.mLauncher = launcherSubsys;
+        this.mLauncher = launcher;
+        this.mCoordSysMgr = new CoordSysMgr2020(); // our private copy
+
         this.mNetTab = NetworkTableInstance.getDefault();
         this.mNetTab.addEntryListener(Constants.Vision.kTargetResultKey, 
                                     this::visionTargetUpdate,
                                     EntryListenerFlags.kUpdate);
-        this.mCoordSysMgr = coordSysMgr;
         this.mListeners = new ArrayList<VisionEvent>();
         this.mVisionEstimates = new ArrayDeque<RobotStateMap.State>();
-        this.mLastTurretAngle = -180.; // in degrees (impossible angle for turret)
-        this.setDefaultCommand(new ListenForTurretAndVision());
         this.dashboardPutString(Constants.Vision.kStatusKey, "ready+waiting");
 
         this.mLEDRelay = new Relay(Constants.Vision.kLEDRelay);
@@ -95,6 +95,13 @@ public class Vision extends SpartronicsSubsystem
                             this.mLEDRelay.get().toString());
     }
 
+    /* VisionEvents -----------------------------------------------*/
+    /**
+     * register interest in vision events - caller may subclass
+     * VisionEvent.  Alternative is just to request access to
+     * the mVisionEstimates queue.
+     * @param l - 
+     */
     public void registerTargetListener(VisionEvent l)
     {
         this.mListeners.add(l);
@@ -110,33 +117,15 @@ public class Vision extends SpartronicsSubsystem
         return this.mVisionEstimates; // nb: is there a threading issue here?
     }
 
-    /**
-     * A currently-unused method that might be of use in the inverted scenario
-     * where we expect the raspi-Vision code to compute robot pose.  Currently
-     * we take the opposite tack: we esimate the pose whenever we receive a
-     * vision target update from raspi.
-     */
-    public void broadcastState()
+    /* LED --------------------------------------------------------*/
+    public boolean isLEDOn()
     {
-        // Here we might compose an easily parsable string containing
-        // current robot pose estimate and timestamp. We could
-        // also include the current turret rotation (and elevation
-        // if the camera is mounted thereupon).
-        //
-        // On the other hand, the RobotStateEstimator currently outputs:
-        // RobotState/pose
-        // RobotState/timeStamp.
-        // If we can rely on the launcher to output:
-        // Launcher/StaticPosition (xy, position relative to robot origin)
-        // Launcher/StaticOrientation (roll, pitch, yaw)
-        // Launcher/TurretAimAngle
-        // Then we really have nothing to contribute yet.
+        return (mLEDRelay.get() == Relay.Value.kForward);
     }
 
-    private void updateTurretAngle(double newangle)
+    public void setLED(boolean onoff)
     {
-        this.mLastTurretAngle = newangle;
-        this.mCoordSysMgr.updateTurretAngle(newangle);
+        mLEDRelay.set(onoff ? Value.kForward : Value.kOff);
     }
 
     /**
@@ -152,14 +141,20 @@ public class Vision extends SpartronicsSubsystem
             // this.logInfo("Turret Target received " + val);
             // here we parse the string and evaluate the field
             // expect a string of the form:
-            // "-33.35 -35.50 -100 22.35557" (camx, camy, camz, timestamp)
+            // "-33.35 -35.50 -100 22.35557 [turretAngle]" (camx, camy, camz, timestamp, turretAngle)
+            // Turret angle may be delivered since its value in the past
+            // is required to estimate robot pose.  If vision doesn't deliver
+            // it, we'll either accept error, assume that the turret doesn't
+            // move or need to extend RobotStateEstimator.state to include this
+            // information.
 
             String[] vals = val.split(" ");
-            assert vals.length == 4;
             double camx = Double.parseDouble(vals[0]);
             double camy = Double.parseDouble(vals[1]);
             double camz = Double.parseDouble(vals[2]);
             double timestamp = Double.parseDouble(vals[3]);
+            double turretAngle = (vals.length == 5) ? 
+                Double.parseDouble(vals[4]) : mLauncher.getTurretDirection().getDegrees();
             Vec3 tgtInCam = new Vec3(camx, camy, camz);
             Vec3 tgtInRobot = this.mCoordSysMgr.camPointToRobot(tgtInCam);
             if (tgtInRobot.a1 <= 0)
@@ -198,7 +193,8 @@ public class Vision extends SpartronicsSubsystem
             }
 
             // here is the inverse estimate -----------------------------
-            mCoordSysMgr.updateRobotPose(robotHeading, tgtInRobot, fieldTarget);
+            this.mCoordSysMgr.updateTurretAngle(turretAngle);
+            this.mCoordSysMgr.updateRobotPose(robotHeading, tgtInRobot, fieldTarget);
             Vec3 robotPos = mCoordSysMgr.robotPointToField(Vec3.ZeroPt);
             // use robot's heading in our poseEstimate - remember to
             // convert from inches to meters.
@@ -217,7 +213,7 @@ public class Vision extends SpartronicsSubsystem
             mVisionEstimates.addLast(state);
 
             // now measure the distance between our estimate and the
-            // official robot estimate.
+            // official robot estimate (at timestamp).
             double derror = robotPos.subtract(Units.metersToInches(t2d.getX()), 
                                               Units.metersToInches(t2d.getY()), 
                                               0).length();
@@ -230,7 +226,7 @@ public class Vision extends SpartronicsSubsystem
             double delay = Timer.getFPGATimestamp() - timestamp;
             this.dashboardPutNumber(Constants.Vision.kPoseLatencyKey, delay);
 
-            // Let's report the combination of official odometry and target
+            // Report the combination of official odometry and target
             // offset. This is a "forward" estimate of our well-known
             // landmarks.  Hopefully these will produce nearly constant
             // and correct (!) results.
@@ -244,108 +240,7 @@ public class Vision extends SpartronicsSubsystem
             this.dashboardPutString(key, tgtInField.asPointString());
         }
         else
-            this.logError("Turret Target value must be a string");
-    }
-
-    /* public interfaces ---------------------------------------------*/
-    /* nb: this can't be defined within SetLEDRelay (inner class in general) */
-    public static enum RelayStateChange
-    {
-        kOff,
-        kOn,
-        kToggle
-    };
-
-    /**
-     * an instant command that can turn on, off or toggle the VisionLED relay.
-     * this probably should be invoked automatically when odometry determines
-     * that we're in a place where vision targeting is enabled.
-     * 
-     * XXX: perhaps this should be the central control for acquisition:
-     *   ie: light is off, we could notify raspi to rest 
-     */
-    public class SetLEDRelay extends InstantCommand
-    {
-        RelayStateChange mStateChange;
-        public SetLEDRelay(RelayStateChange c)
-        {
-            super(); 
-            // NB: I think it's legit to say 'no subsystem requirements'.
-            // since we're the only one who cares about this relay.
-            // Now we won't unschedule our default command on each toggle.
-            mStateChange = c;
-        }
-
-        @Override
-        public void initialize()
-        {
-            // this is where InstantCommand does its thing
-            Relay.Value oldstate = mLEDRelay.get();
-            Relay.Value newstate;
-            boolean isOn;
-            switch(mStateChange)
-            {
-            case kOff:
-                newstate = Relay.Value.kOff;
-                isOn = false;
-                break;
-            case kOn:
-                newstate = Relay.Value.kForward;
-                isOn = true;
-                break;
-            case kToggle:
-            default:
-                newstate = (oldstate == Relay.Value.kForward) ? 
-                                Relay.Value.kOff : Relay.Value.kForward;
-                isOn = (newstate == Relay.Value.kOff) ? false : true;
-                break;
-            }
-            mLEDRelay.set(newstate);
-            dashboardPutBoolean(Constants.Vision.kLEDRelayKey, isOn);
-        }
-    }
-
-    /* private interfaces ---------------------------------------------*/
-    /**
-     * ListenForTurretAndVision is this subsystem's default command.
-     * We listen for changes to the relay state nettab value - possibly
-     * changed by dashboard or even raspi vision.
-     */
-    private class ListenForTurretAndVision extends CommandBase
-    {
-        public ListenForTurretAndVision()
-        {
-            this.addRequirements(Vision.this);
-        }
-
-        @Override
-        public void execute()
-        {
-            // synchronize mLEDRelay with LEDRelay network table value.
-            boolean isOn = dashboardGetBoolean(Constants.Vision.kLEDRelayKey, true);
-            Relay.Value oldstate = mLEDRelay.get();
-            if(isOn)
-            {
-                if(oldstate != Relay.Value.kForward)
-                    mLEDRelay.set(Relay.Value.kForward);
-            }
-            else
-            {
-                if(oldstate != Relay.Value.kOff)
-                    mLEDRelay.set(Relay.Value.kOff);
-            }
-            double turretAngle = mLauncher.getTurretDirection().getDegrees();
-            if(Math.abs(turretAngle - mLastTurretAngle) > .5)
-            {
-                updateTurretAngle(turretAngle);
-            }
-        }
-
-        @Override
-        public boolean isFinished()
-        {
-            return false; // for clarity, we're always in this mode
-        }
+            this.logError("Vision target value must be a string");
     }
 
 }

--- a/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
+++ b/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
@@ -1,7 +1,7 @@
 package com.spartronics4915.lib.math.threedim;
 
 /**
- * CameraToField captures the coordinate-system chain (kinematics) associated
+ * CoordSysMgr captures the coordinate-system chain (kinematics) associated
  * with a camera mounted on a potentially-moving mount attached to a robot.
  * To produce season-specific behavior, please subclass this class.
  * 

--- a/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
+++ b/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
@@ -1,5 +1,8 @@
 package com.spartronics4915.lib.math.threedim;
 
+import com.spartronics4915.lib.math.twodim.geometry.*;
+import com.spartronics4915.lib.util.Units;
+
 /**
  * CoordSysMgr captures the coordinate-system chain (kinematics) associated
  * with a camera mounted on a potentially-moving mount attached to a robot.
@@ -107,6 +110,22 @@ public class CoordSysMgr
     {
         this.mMountToRobot = mToR;
         this.mDirty = true;
+    }
+
+    /**
+     * update internal state (in inches) via a standard Pose2d (in meters)
+     * representations.
+     * @param fieldToVehicle - usually obtained via
+     *  RobotStateMap.getLatestFieldToVehicle.
+     */
+    public void updateRobotPose(Pose2d fieldToVehicle)
+    {
+        Translation2d td = fieldToVehicle.getTranslation();
+        double x = Units.metersToInches(td.getX());
+        double y = Units.metersToInches(td.getY());
+        double angle = fieldToVehicle.getRotation().getDegrees();
+
+        this.updateRobotPose(x, y, angle);
     }
 
     /**

--- a/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
+++ b/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
@@ -7,7 +7,9 @@ import com.spartronics4915.lib.util.Units;
  * CoordSysMgr captures the coordinate-system chain (kinematics) associated
  * with a camera mounted on a potentially-moving mount attached to a robot.
  * To produce season-specific behavior, please subclass this class.
- * 
+ */
+
+/*
  * Robot field pose (ie: robot position/heading in field coordinates)
  * aka the robotToField 
  *
@@ -113,10 +115,9 @@ public class CoordSysMgr
     }
 
     /**
-     * update internal state (in inches) via a standard Pose2d (in meters)
-     * representations.
-     * @param fieldToVehicle - usually obtained via
-     *  RobotStateMap.getLatestFieldToVehicle.
+     * Updates internal state via a standard Pose2d (assumed in meters).
+     * @param fieldToVehicle - usually obtained via 
+     *   RobotStateMap.getLatestFieldToVehicle.
      */
     public void updateRobotPose(Pose2d fieldToVehicle)
     {
@@ -129,8 +130,8 @@ public class CoordSysMgr
     }
 
     /**
-     * Periodically update the robot pose via a string
-     * @param rposeString "x y angle" (angle in degrees)
+     * Updates robot pose via a string.
+     * @param rposeString "x y angle" x, y in inches, angle in degrees
      */
     public void updateRobotPose(String rposeString)
     {
@@ -143,9 +144,9 @@ public class CoordSysMgr
     }
 
     /**
-     * Periodically update internal notion of robot pose via numbers.
-     * @param x - x coordinate of robot origin on field
-     * @param y - y coordinate of robot origin on field
+     * Updates internal notion of robot pose via numbers.
+     * @param x - x coordinate of robot origin on field in inches
+     * @param y - y coordinate of robot origin on field in inches
      * @param angle - heading of robot in degrees.  If x of robot points to 
      * x of field, the angle is zero.
      */
@@ -162,8 +163,10 @@ public class CoordSysMgr
      * and the known field coordinates of the same target, compute the
      * full robotToField coordinates.
      * @param knownHeading - measured in degrees in field coordinates
-     * @param robotTgt - target pt in robot coordinates (from vision)
-     * @param fieldTgt - known target location in field coords
+     * @param robotTgt - target pt in robot coordinates (from vision) -
+     *   measured in inches.
+     * @param fieldTgt - known target location in field coords - measured
+     *   in inches.
      */
     public void updateRobotPose(double knownHeading, final Vec3 robotTgt, 
                                 final Vec3 fieldTgt)
@@ -238,7 +241,7 @@ public class CoordSysMgr
      * transformation can be used to compute a shooting distance as
      * follows:  
      *    Vec3 dist = camPointToMount(camTargetPt);
-     *    dist.a2 = 0; // we don't care about height
+     *    dist.a2 = 0; // if we don't care about height
      *    double distance = dist.length();
      */
     public Vec3 camPointToMount(Vec3 pt)

--- a/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
+++ b/src/main/java/com/spartronics4915/lib/math/threedim/CoordSysMgr.java
@@ -39,17 +39,17 @@ package com.spartronics4915.lib.math.threedim;
  *                |___|     |        x
  */
 
-public class CameraToField
+public class CoordSysMgr
 {
     private Affine3 mCamToMount;
     private Affine3 mMountToRobot;
+    private Affine3 mFieldToMount;
     private Affine3 mCamToRobot;
     private Affine3 mRobotToField;
     private Affine3 mCamToField;
-    private Affine3 mFieldToMount;
     private boolean mDirty;
 
-    public CameraToField()
+    public CoordSysMgr()
     {
         mCamToMount = new Affine3();
         mMountToRobot = new Affine3();
@@ -254,6 +254,12 @@ public class CameraToField
     {
         this._rebuildTransforms();
         return this.mFieldToMount.transformVector(dir);
+    }
+
+    public Vec3 fieldPointToMount(Vec3 pt)
+    {
+        this._rebuildTransforms();
+        return this.mFieldToMount.transformVector(pt);
     }
 
     /**

--- a/src/main/java/com/spartronics4915/lib/math/threedim/Vec3.java
+++ b/src/main/java/com/spartronics4915/lib/math/threedim/Vec3.java
@@ -129,9 +129,21 @@ public class Vec3 extends DMatrix3
         return true;
     }
 
+    /**
+     * @return lenght of 3D vector. aka: distance of 3d point from origin.
+     */
     public double length()
     {
         return NormOps_DDF3.normF(this);
+    }
+
+    /**
+     * @return - length of xy components of vector.
+     *   aka: distance of xy point from origin.
+     */
+    public double lengthXY()
+    {
+        return Math.sqrt(this.a1*this.a1 + this.a2*this.a2);
     }
 
     public void normalize()

--- a/src/main/java/com/spartronics4915/lib/math/twodim/geometry/Pose2d.java
+++ b/src/main/java/com/spartronics4915/lib/math/twodim/geometry/Pose2d.java
@@ -12,24 +12,42 @@ public class Pose2d implements State<Pose2d>
     private final Translation2d mTranslation;
     private final Rotation2d mRotation;
 
+    /**
+     * construct default Pose2d
+     */
     public Pose2d()
     {
         mTranslation = new Translation2d();
         mRotation = new Rotation2d();
     }
 
+    /**
+     * construct Pose2d from params
+     * @param x 
+     * @param y
+     * @param rotation (a Rotation2d)
+     */
     public Pose2d(double x, double y, final Rotation2d rotation)
     {
         mTranslation = new Translation2d(x, y);
         mRotation = rotation;
     }
 
+    /**
+     * construct a Pose2d from parameters
+     * @param translation (a Translation2d)
+     * @param rotation (a Rotation2d)
+     */
     public Pose2d(final Translation2d translation, final Rotation2d rotation)
     {
         mTranslation = translation;
         mRotation = rotation;
     }
 
+    /**
+     * copy-construct a Pose2d
+     * @param other
+     */
     public Pose2d(final Pose2d other)
     {
         mTranslation = new Translation2d(other.mTranslation);

--- a/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
+++ b/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
@@ -17,23 +17,51 @@ class CoordSysMgrTest
         ctof.updateTurretAngle(0);
 
         // robot at center of field, pointing right
-        ctof.updateRobotPose(320, 0, 0);
+        Vec3 robotPt = new Vec3(320, 0, 0);
+        double robotHeading = 0;
+        ctof.updateRobotPose(robotPt.a1, robotPt.a2, robotHeading);
 
-        Vec3 camOnField = ctof.camPointToField(new Vec3(0, 0, 0));
-        assert(camOnField.equals(new Vec3(316.28,17.264,8) , kEpsilon));
+        // This should give us the location of the camera relative to the robot
+        // when turret angle is 0.
+        Vec3 camOnRobot = ctof.camPointToRobot(Vec3.ZeroPt);
+        double dist = camOnRobot.length(), distXY;
+        assert(dist > 5 && dist < 20);
+        // for a robot and turret angle of 0, predict camera position on field.
+        Vec3 camPtOnField = ctof.camPointToField(new Vec3(0, 0, 0));
         Vec3 camDirOnField = ctof.camDirToField(new Vec3(0, 0, -1));
         assertEquals(camDirOnField.a1, -1, .2); // camera tilts into z-up
         assertEquals(camDirOnField.a2, 0, kEpsilon); // camera tilts into z-up
+        distXY = camPtOnField.subtract(robotPt).lengthXY();
+        assert(distXY < 18);
 
-        // let's see where a point 100 inches away from camera is
-        // should be "behind the robot" on at y == 12 (which is cam offset)
-        Vec3 p1 = ctof.camPointToField(new Vec3(0, 0, -100));
-        assertEquals(p1.a2, 12, kEpsilon);
+        // Let's see where a point 100 inches away from camera is
+        // should be "behind the robot" offset by combination of
+        // turret and camera offsets.
+        Vec3 p0 = ctof.camPointToRobot(new Vec3(0, 0, -100));
+        assert(p0.a1 < -100); // mostly behind the robot (x is front)
+        distXY = p0.lengthXY();
+        assert(distXY > 100); // farther from robot than camera (even xy only)
+
+        // Now point turret directly toward turret right (robot left)
+        ctof.updateTurretAngle(-90); // turret x is fwd, +y is left
+        p0 = ctof.camPointToRobot(new Vec3(0, 0, -100));
+        assert(p0.a2 > 100); // mostly to the left of the robot (+y is left)
+        distXY = p0.lengthXY();
+        assert(distXY > 100); // since robot origin is farther from target
+
+        // point turret directly left
+        ctof.updateTurretAngle(90);
+        p0 = ctof.camPointToRobot(new Vec3(0, 0, -100));
+        assert(p0.a2 < -90); // mostly to the left of the robot (+y is left)
+        double distXY2 = p0.length();
+        // robot origin closer to points turret sees to its right.
+        assert(distXY2 < distXY); 
 
         // robot heading north, target below/right, 45 degrees,
         // variant of updateRobotPose that estimates the robot transform
         // given a measurement and an expected location.
-        double robotHeading = 90;
+        ctof.updateTurretAngle(0);
+        robotHeading = 90;
         Vec3 robotRelativeTarget = new Vec3(-100, -100, 96);
         Vec3 knownFieldLocationTarget = new Vec3(628, -67.5, 96);
         ctof.updateRobotPose(robotHeading, robotRelativeTarget, knownFieldLocationTarget);
@@ -55,11 +83,12 @@ class CoordSysMgrTest
 
 
         // robot heading west (field x+) at midfield
+        robotHeading = 0;
         Vec3 robotPoint = new Vec3(320, 0, 0); 
         // target point is blue alliance target in lower right
         Vec3 targetPoint = new Vec3(628, -67.5, 0); 
         Vec3 targetDir = targetPoint.subtract(robotPoint).asUnit();
-        ctof.updateRobotPose(320, 0, 0);
+        ctof.updateRobotPose(320, 0, robotHeading);
         // mount direction should be negative (ie > 90 && < 270)
         // note that this angle will always be positive and doesn't
         // imply the sign of the rotation angle for the turret
@@ -73,7 +102,8 @@ class CoordSysMgrTest
         assertEquals(mountAngle, 167.6, .05);
 
         // now let's reverse our robot
-        ctof.updateRobotPose(320, 0, 180);
+        robotHeading = 180;
+        ctof.updateRobotPose(320, 0, robotHeading);
         mountDir = ctof.fieldDirToMount(targetDir);
         mountAngle = mountDir.angleOnXYPlane();
         assertEquals(mountAngle, -12.4, .05);

--- a/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
+++ b/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
@@ -1,7 +1,6 @@
 package com.spartronics4915.frc2020;
 
 import com.spartronics4915.lib.math.threedim.*;
-import com.spartronics4915.lib.math.twodim.geometry.Rotation2d;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
+++ b/src/test/java/com/spartronics4915/frc2020/CoordSysMgrTest.java
@@ -7,21 +7,21 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
-class CamToFieldTests
+class CoordSysMgrTest
 {
     double kEpsilon = 1e-9;
 
     @Test
     public void usageExample()
     {
-        CamToField2020 ctof = new CamToField2020();
-        ctof.updateTurretAngle(new Rotation2d());
+        CoordSysMgr2020 ctof = new CoordSysMgr2020();
+        ctof.updateTurretAngle(0);
 
         // robot at center of field, pointing right
         ctof.updateRobotPose(320, 0, 0);
 
         Vec3 camOnField = ctof.camPointToField(new Vec3(0, 0, 0));
-        assert(camOnField.equals(new Vec3(305,12,8) , kEpsilon));
+        assert(camOnField.equals(new Vec3(316.28,17.264,8) , kEpsilon));
         Vec3 camDirOnField = ctof.camDirToField(new Vec3(0, 0, -1));
         assertEquals(camDirOnField.a1, -1, .2); // camera tilts into z-up
         assertEquals(camDirOnField.a2, 0, kEpsilon); // camera tilts into z-up


### PR DESCRIPTION
Goal is to encourage use of CamToField for field position inferences.
Provided alternate method to Launcher for turret tracking.  Might be good to verify that both old and new methods produce the same results.

Big new issue of the day:  since Vision captures a target at a point in the past, we must also convey the turret orientation at that point in history.  This is currently not present in the RobotStateMap (but we could add it).  The other approach is for Vision to capture the state of "Launcher/turretAngle" along with the timestamp and then transmit the turretAngle back to the Vision subsystem.