### PR TITLE
Removed error related debug notices

### DIFF
--- a/src/main/java/com/spartronics4915/frc2020/subsystems/LED.java
+++ b/src/main/java/com/spartronics4915/frc2020/subsystems/LED.java
@@ -118,8 +118,8 @@ public class LED extends SpartronicsSubsystem
         // If NOT initialized we should not be calling any LED methods
         if (!isInitialized())
         {
-            logError("LED: setBlingState called but LED subsystem is NOT initialized!");
-            dashboardPutString("LED state:", "NOT initialized");
+            // logError("LED: setBlingState called but LED subsystem is NOT initialized!");
+            // dashboardPutString("LED state:", "NOT initialized");
             return;
         }
 
@@ -130,8 +130,8 @@ public class LED extends SpartronicsSubsystem
         byte[] message = mBlingState.getBlingMessage();
         if (mBlingPort.writeBytes(message, message.length) == -1)
         {
-            logError("LED: Error writing to SerialPort - uninitializing LED subsystem");
-            dashboardPutString("LED state:", "Write Error!");
+            // logError("LED: Error writing to SerialPort - uninitializing LED subsystem");
+            // dashboardPutString("LED state:", "Write Error!");
             logInitialized(false);
         }
         else


### PR DESCRIPTION
Note: This only impacts the LED debug messages. It is an effort to clean up the logs from unneeded error messages as LED is not mounted.